### PR TITLE
sec: add Trivy image-scan gate + Keycloak hardening (GA-focus #2)

### DIFF
--- a/.github/workflows/trivy-image-scan.yml
+++ b/.github/workflows/trivy-image-scan.yml
@@ -1,0 +1,26 @@
+name: Trivy Image Scan
+on:
+  pull_request:
+    paths: ["**/Dockerfile", ".github/workflows/trivy-image-scan.yml"]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aquasecurity/trivy-action@0.16.0
+        with:
+          scan-type: "fs"
+          ignore-unfixed: true
+          format: "sarif"
+          output: "trivy-results.sarif"
+      - name: Upload Trivy report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"

--- a/deploy/compose-overrides/keycloak-secure.yml
+++ b/deploy/compose-overrides/keycloak-secure.yml
@@ -1,0 +1,9 @@
+services:
+  keycloak:
+    environment:
+      - KC_PROXY=edge
+      - KC_HOSTNAME_STRICT=true
+      - KC_HOSTNAME=auth.local.dev
+      - KC_HOSTNAME_STRICT_HTTPS=true
+      - KEYCLOAK_ADMIN_FILE=/run/keycloak/admin
+      - KEYCLOAK_ADMIN_PASSWORD_FILE=/run/keycloak/admin

--- a/docs/keycloak-hardening.md
+++ b/docs/keycloak-hardening.md
@@ -1,0 +1,22 @@
+# Keycloak Hardening Guide 🔐 *(Draft)*
+
+> **Scope:** GA v3.0.0 — baseline security posture.
+
+## 1  Admin User
+```bash
+export KEYCLOAK_ADMIN=alfred-admin
+export KEYCLOAK_ADMIN_PASSWORD="$(openssl rand -base64 24)"
+```
+Set via Docker/Helm secrets.
+
+## 2  Themes & Login
+- Disable user self-registration.
+- Require email verification.
+
+## 3  HTTPS
+Use ingress terminating TLS (cert-manager cluster issuer).
+
+## 4  Backup & Upgrade
+Scheduled `kc.sh export` nightly to MinIO.
+
+<\!-- TODO: add OPA policy link once integrated -->

--- a/security/keycloak/realm-export.json
+++ b/security/keycloak/realm-export.json
@@ -1,0 +1,3 @@
+{
+  "_comment": "Placeholder: import-export JSON for hardened realm once finalized."
+}


### PR DESCRIPTION
Adds Trivy CVE gate to CI and baseline Keycloak hardening docs/config.

Closes part of immediate-focus item **Security touch-ups**.