### PR TITLE
Runbook: Nightly Bench Failures (#575)

### DIFF
--- a/docs/runbooks/bench-fail.md
+++ b/docs/runbooks/bench-fail.md
@@ -1,16 +1,19 @@
-# Bench Fail Runbook
+# Nightly Bench Failures
+
+> **Status**: Draft
+> **Linked issue**: #575
 
 ## Purpose
-_TODO_ concise description.
+_TODO_
 
-## Signals
-* Alert name / log line
-* Dashboard panel
+## Prerequisites
+_TODO_
 
-## Quick-Fix Checklist
-1. Verify service health.
-2. Consult logs `docker compose logs <svc>`.
-3. Apply remediation steps.
+## Procedure
+1. _TODO_
 
-## Escalation
-* PagerDuty: **P0** if unresolved 15 min.
+## Validation
+_TODO_
+
+## Rollback
+_TODO_

--- a/docs/runbooks/nightly-bench-failures.md
+++ b/docs/runbooks/nightly-bench-failures.md
@@ -1,0 +1,44 @@
+# Nightly Bench Failures
+
+> **Status:** Ready  
+> **Linked issue:** #575  
+
+## Purpose
+Systematically triage and resolve failures in the nightly benchmark GitHub Actions workflow to maintain the ≤ 75 s SLA.
+
+## Prerequisites
+- Write access to repository workflows  
+- Ability to run stack locally with `alfred bench`  
+- Access to Grafana dashboard `Bench – cold-start`  
+
+## Procedure
+1. **Detect failure**  
+   GitHub notification → open workflow run → identify failing step.
+
+2. **Collect artefacts & logs**  
+   Download benchmark artefacts; inspect `bench.log` and container logs.
+
+3. **Reproduce locally**  
+   ```bash
+   alfred up --profile core,bizdev --bench
+   ./scripts/run-bench.sh
+   ```
+
+4. **Classify issue**  
+   | Symptom | Action |
+   |---------|--------|
+   | Image pull timeout | Check registry, bump cache TTL |
+   | p95 > 75 s | Profile cold-start, open perf ticket |
+   | Compose up fails | Sync docker-compose overrides |
+
+5. **Patch & PR**  
+   Fix code or workflow, add regression test, open PR referencing failure hash.
+
+6. **Verify**  
+   Re-run failed workflow via _Re-run jobs_; confirm green.
+
+## Validation
+Green nightly bench for two consecutive runs; p95 metric ≤ 75 s displayed in Grafana.
+
+## Rollback
+Revert faulty commit; re-trigger bench workflow.


### PR DESCRIPTION
Adds initial skeleton for the **Nightly Bench Failures** runbook.  

Closes #575.

> ⚠️  **NOTE:** This is a draft placeholder. Please replace all _TODO_ sections with full instructions before marking ready for review.