### PR TITLE
chore: add bench.compose.yml (#583)

### DIFF
--- a/bench.compose.yml
+++ b/bench.compose.yml
@@ -1,0 +1,39 @@
+services:
+  # Only services with truly public images for CI cold-start testing
+
+  db-postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: alfred
+      POSTGRES_PASSWORD: testpass
+      POSTGRES_DB: alfred
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "alfred"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  # Mock agent services with simple HTTP servers
+  agent-core:
+    image: nginx:alpine
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:80"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  agent-bizdev:
+    image: nginx:alpine
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:80"]
+      interval: 5s
+      timeout: 5s
+      retries: 5

--- a/metrics/scripts_inventory.csv
+++ b/metrics/scripts_inventory.csv
@@ -274,6 +274,7 @@ scripts/find_orphan_candidates.py,.py,1342,UNKNOWN
 scripts/fix-agent-rag-only.sh,.sh,1300,UNKNOWN
 scripts/fix-agent-rag-service.sh,.sh,1910,UNKNOWN
 scripts/fix-auth-roles.sh,.sh,1993,UNKNOWN
+scripts/fix-bench-compose.sh,.sh,1951,UNKNOWN
 scripts/fix-ci-failures.sh,.sh,1505,UNKNOWN
 scripts/fix-clean-healthchecks.sh,.sh,1875,UNKNOWN
 scripts/fix-db-storage.sh,.sh,5164,UNKNOWN


### PR DESCRIPTION
Adds **bench.compose.yml** (copied from CI compose) to fix the failing benchmark workflow.

Closes #583.