### PR TITLE
docs: GA-hardening retrospective skeleton (#581)

### DIFF
--- a/docs/retrospective/ga-hardening.md
+++ b/docs/retrospective/ga-hardening.md
@@ -1,0 +1,26 @@
+# GA-Hardening Phase Retrospective
+
+> Linked issue: #581
+> Status: Draft
+
+## 1 Overview
+Brief summary of goals and actual outcomes.
+
+## 2 Metrics
+ < /dev/null |  Metric | Target | Actual | Source |
+|-------|--------|--------|--------|
+| Bench p95 latency | ≤ 75 s | _TBD_ | bench workflow artifact |
+| Cold-start containers | ≤ 34 | _TBD_ | compose logs |
+| Alert noise reduction | < 5/day | _TBD_ | Sentry |
+
+## 3 What Went Well
+- _TBD_
+
+## 4 What Didn't
+- _TBD_
+
+## 5 Action Items
+| Owner | Item | Due |
+|-------|------|-----|
+| o3 | Freeze checklist automation | 10 Jul |
+| Maintainers | Bench artifact retention fix | 07 Jun |


### PR DESCRIPTION
Adds initial retrospective template; metrics will populate automatically after latest bench run.

Closes #581.