### PR TITLE
fix(ci): convert repository name to lowercase for Docker registry

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -95,6 +95,8 @@ jobs:
           else
             echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
+          # Convert repository name to lowercase for Docker registry
+          echo "repository=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Build & push ${{ matrix.name }}
         uses: docker/build-push-action@v5
@@ -102,7 +104,7 @@ jobs:
           provenance: false
           sbom: false
           push: true
-          tags: ghcr.io/${{ github.repository }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+          tags: ghcr.io/${{ steps.tag.outputs.repository }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
           file: ${{ matrix.dockerfile }}
           context: ${{ matrix.context }}
           platforms: linux/amd64


### PR DESCRIPTION
## Summary

This PR fixes the Docker image build workflow that was failing for v3.0.0 GA release.

## Problem
The workflow was using  directly, which contains uppercase letters ("Digital-Native-Ventures"). Docker registries require lowercase repository names, causing builds to fail with:
```
ERROR: invalid tag "ghcr.io/Digital-Native-Ventures/alfred-agent-platform-v2/alfred-core:v3.0.0": repository name must be lowercase
```

## Solution
Added a step to convert the repository name to lowercase before using it in the Docker tag.

## Testing
- The fix uses standard shell command `tr '[:upper:]' '[:lower:]'` to convert to lowercase
- This will allow the v3.0.0 images to be built and pushed successfully

## Related
- Failed workflow run: https://github.com/Digital-Native-Ventures/alfred-agent-platform-v2/actions/runs/15286596088
- This blocks the v3.0.0 GA release container images