### PR TITLE
docs: publish v0.9.13-beta1 notes & update latest baseline doc

### DIFF
--- a/docs/release-notes/latest.md
+++ b/docs/release-notes/latest.md
@@ -1,0 +1,1 @@
+**Baseline updated to 11 services.** See v0.9.13-beta1 release notes for details.


### PR DESCRIPTION
Updates documentation for the v0.9.13-beta1 release:
- Update CHANGELOG.md with release entry
- Create docs/release-notes/latest.md to document the new 11-service baseline

This is a documentation-only change.