### PR TITLE
fix(p0): vector-ingest port 8000 exposure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1068,6 +1068,8 @@ services:
     container_name: vector-ingest
     environment:
       EMBED_MODEL: sentence-transformers/all-MiniLM-L6-v2
+    ports:
+      - "8000:8000"
     depends_on:
       vector-db:
         condition: service_healthy


### PR DESCRIPTION
Adds ports section to docker-compose so the FastAPI /health endpoint is reachable. Unblocks cold-start SLA test.