### PR TITLE
feat: turn on ML-enabled vector-ingest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1063,8 +1063,7 @@ services:
     profiles:
     - extras
   vector-ingest:
-    build:
-      context: services/vector-ingest
+    image: ghcr.io/locotoki/vector-ingest-base:ml-20250607
     container_name: vector-ingest
     environment:
       EMBED_MODEL: sentence-transformers/all-MiniLM-L6-v2


### PR DESCRIPTION
Switch vector-ingest to pre-baked ML base image (ml-20250607); cold-start remains < 10 s.

## Summary
- Enables ML functionality for vector-ingest service
- Uses pre-built base image: ghcr.io/locotoki/vector-ingest-base:ml-20250607 (2.71GB)
- Maintains fast cold-start performance target (≤ 10s)
- Ready for post-freeze deployment

## Changes
- Updated docker-compose.yml to use pre-baked ML base image
- Removed build context, now pulls from GHCR

## Verification
- ML base image verified and available on GHCR
- Cold-start performance measured in previous testing