### PR TITLE
fix(p0): use lowercase repository name for GHCR

### DIFF
--- a/.github/workflows/build-sign-push.yml
+++ b/.github/workflows/build-sign-push.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.tag }}
+          tags: ghcr.io/${{ github.repository_owner }}/alfred-agent-platform-v2:${{ steps.tag.outputs.tag }}
           provenance: true        # SLSA 2 attestation
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
@@ -41,11 +41,11 @@ jobs:
         env:
           COSIGN_REPOSITORY: "ghcr.io/${{ github.repository_owner }}/alfred-agent-platform-v2"
         run: |
-          cosign sign --yes ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.tag }}
+          cosign sign --yes ghcr.io/${{ github.repository_owner }}/alfred-agent-platform-v2:${{ steps.tag.outputs.tag }}
       - name: Generate SBOM (CycloneDX+SPDX)
         uses: anchore/sbom-action@v0
         with:
-          image: ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.tag }}
+          image: ghcr.io/${{ github.repository_owner }}/alfred-agent-platform-v2:${{ steps.tag.outputs.tag }}
           format: spdx-json,cyclonedx-json
       - name: Upload SBOM to release (if tag)
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Fix GHCR repository name to use lowercase format.

## Problem
- GHCR requires lowercase repository names
- GitHub repository name contains uppercase letters
- Signing workflow failing with 'repository name must be lowercase'

## Solution  
- Use `github.repository_owner/alfred-agent-platform-v2` instead of `github.repository`
- Ensures consistent lowercase naming for GHCR images
- Fixes signing and SBOM generation

## Impact
- Enables successful container signing for tagged releases
- Fixes v1.0.1 and future release signing workflows