### PR TITLE
fix(p0): build vector-ingest for signing workflow

### DIFF
--- a/.github/workflows/build-sign-push.yml
+++ b/.github/workflows/build-sign-push.yml
@@ -2,10 +2,10 @@ name: build-sign-push
 on:
   push:
     tags:
-      - "v*"    # run on tags as well
+      - "v*"    # run on tags (no path filter)
     branches:
       - main
-    paths: ['services/**/Dockerfile']
+    paths: ['services/**/Dockerfile']  # path filter only applies to branches
   workflow_dispatch:
 jobs:
   build-sign:
@@ -34,7 +34,8 @@ jobs:
       - name: Build & push
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: services/vector-ingest
+          file: services/vector-ingest/Dockerfile
           push: true
           tags: ghcr.io/${{ steps.tag.outputs.repo }}:${{ steps.tag.outputs.tag }}
           provenance: true        # SLSA 2 attestation


### PR DESCRIPTION
Enable vector-ingest container building for signing workflow.

## Problem
- Workflow fails with 'no Dockerfile found' on tag builds
- Repository has service-specific Dockerfiles, not root Dockerfile
- Need to build actual container for signing verification

## Solution
- Set build context to `services/vector-ingest`
- Specify Dockerfile location explicitly
- Build vector-ingest container for tag-based signing
- Maintain current path filtering for branch pushes

## Expected Result
- v1.0.4 tag should successfully build vector-ingest container
- Container gets signed with cosign keyless signing
- SBOM generation works properly