### PR TITLE
fix(p0): add Docker login for GHCR push

### DIFF
--- a/.github/workflows/build-sign-push.yml
+++ b/.github/workflows/build-sign-push.yml
@@ -11,12 +11,19 @@ jobs:
   build-sign:
     permissions:
       contents: write
+      packages: write   # GHCR push
       id-token: write   # keyless signing
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU & Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set image tag and repo
         id: tag
         run: |


### PR DESCRIPTION
Add authentication for container registry pushing.

## Problem
- Workflow fails with 403 Forbidden when pushing to GHCR
- Missing Docker login step for authentication
- Missing packages: write permission

## Solution
- Add \ with GHCR registry
- Use \ for authentication
- Add \ permission
- Enable pushing signed containers to registry

## Expected Result
- v1.0.5 should successfully build, push, and sign container