### PR TITLE
feat: cold-start alert rule

### DIFF
--- a/prometheus/alerts/cold_start.yml
+++ b/prometheus/alerts/cold_start.yml
@@ -9,3 +9,13 @@ groups:
     annotations:
       summary: "Cold-start exceeds 60 s"
       description: "The nightly benchmark cold-start SLA (>60 s) breached for 3 minutes."
+- name: vector-ingest
+  rules:
+  - alert: VectorIngestColdStartTooHigh
+    expr: vector_ingest_cold_start_seconds > 60
+    for: 5m
+    labels:
+      severity: page
+    annotations:
+      summary: "Vector-ingest cold-start SLA breach"
+      description: "cold-start has been >60s for 5m"


### PR DESCRIPTION
## Summary
Adds Prometheus alert rule for vector-ingest cold-start monitoring.

## Details
- Alert: VectorIngestColdStartTooHigh
- Threshold: > 60 seconds
- Duration: 5 minutes
- Severity: page

This alert will fire when the vector-ingest service cold-start time exceeds our 60-second SLA for more than 5 minutes.

## Testing
- Alert rule syntax validated
- Will be tested in staging environment post-merge

Resolves #694
EOF < /dev/null
