### PR TITLE
fix: Use ARCHITECT_PAT for Architect Review authentication

### DIFF
--- a/.github/workflows/architect_review.yml
+++ b/.github/workflows/architect_review.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       AUTO_MERGE: ${{ secrets.AUTO_MERGE || 'false' }}
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.ARCHITECT_PAT }}
     steps:
       - uses: actions/checkout@v4
         with: { submodules: recursive }

--- a/.github/workflows/architect_review.yml
+++ b/.github/workflows/architect_review.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/setup-python@v5
         with: { python-version: '3.11' }
       - run: pip install openai ghapi
+      - name: Setup gh auth
+        run: echo "$GH_TOKEN" | gh auth login --with-token
       - name: Extract task row
         id: task
         run: |


### PR DESCRIPTION
## Summary

Fixes the GitHub API 'self-review' limitation by using ARCHITECT_PAT instead of github.token for the Architect Review workflow.

## Changes
- Update `.github/workflows/architect_review.yml` to use `secrets.ARCHITECT_PAT`
- Enables Architect bot to review Engineer PRs without 'cannot review own PR' errors
- Allows auto-merge functionality to work properly

## Test Plan
- [ ] Merge this PR to main
- [ ] Test with next Engineer PR (should auto-review and auto-merge)

🤖 Generated with [Claude Code](https://claude.ai/code)