### PR TITLE
mark task #003 complete

### DIFF
--- a/planning/architect-plan.md
+++ b/planning/architect-plan.md
@@ -11,7 +11,7 @@ Use [ ] for unchecked tasks and [x] for completed ones. -->
 |--------|-----|-----------------------------|-------------------------------------------------------|
 | [x]    | 001 | PR #710                     | Enable optional E2E & perf-stress jobs                |
 | [x]    | 002 | PR #710                     | Make flake-detector a required gate                   |
-| [ ]    | 003 | Issue #695                  | Kick-off Dependabot + weekly Trivy automation         |
+| [x]    | 003 | Issue #695                  | Kick-off Dependabot + weekly Trivy automation         |
 | [ ]    | 004 | Migrate_Slack_Adapter.md    | Migrate Slack adapter from ngrok to Cloudflare Tunnel |
 | [ ]    | 005 | Slack_Manifest_Update.md    | Update Slack manifest for Cloudflare Tunnel migration |
 | [ ]    | 006 | Issue #697                  | Begin BizDev agent scaffold                           |

--- a/planning/architect-plan.md
+++ b/planning/architect-plan.md
@@ -3,15 +3,13 @@ Generate a task breakdown from the planning bullets below.
 Return a markdown table with columns: | Status | ID | File | Description |.  
 Use [ ] for unchecked tasks and [x] for completed ones. -->
 
-## Planning bullets
-- Fix task-ticker trigger (remove branches-ignore: [main])
-- Deploy architect_review.yml auto-merge workflow to main
-
-| Status | ID  | File                        | Description                                           |
-|--------|-----|-----------------------------|-------------------------------------------------------|
-| [x]    | 001 | PR #710                     | Enable optional E2E & perf-stress jobs                |
-| [x]    | 002 | PR #710                     | Make flake-detector a required gate                   |
-| [x]    | 003 | Issue #695                  | Kick-off Dependabot + weekly Trivy automation         |
-| [ ]    | 004 | Migrate_Slack_Adapter.md    | Migrate Slack adapter from ngrok to Cloudflare Tunnel |
-| [ ]    | 005 | Slack_Manifest_Update.md    | Update Slack manifest for Cloudflare Tunnel migration |
-| [ ]    | 006 | Issue #697                  | Begin BizDev agent scaffold                           |
+| Status | ID  | File                       | Description                                               |
+|--------|-----|----------------------------|-----------------------------------------------------------|
+| [ ]    | 007 | task-ticker.yml            | Fix task-ticker trigger by removing branches-ignore: [main] |
+| [ ]    | 008 | architect_review.yml       | Deploy architect_review.yml auto-merge workflow to main   |
+| [x]    | 001 | PR #710                    | Enable optional E2E & perf-stress jobs                    |
+| [x]    | 002 | PR #710                    | Make flake-detector a required gate                       |
+| [x]    | 003 | Issue #695                 | Kick-off Dependabot + weekly Trivy automation             |
+| [ ]    | 004 | Migrate_Slack_Adapter.md   | Migrate Slack adapter from ngrok to Cloudflare Tunnel     |
+| [ ]    | 005 | Slack_Manifest_Update.md   | Update Slack manifest for Cloudflare Tunnel migration     |
+| [ ]    | 006 | Issue #697                 | Begin BizDev agent scaffold                               |

--- a/tasks/task-queue.md
+++ b/tasks/task-queue.md
@@ -2,7 +2,7 @@
 |--------|-----|-----------------------------|-------------------------------------------------------|
 | [x]    | 001 | PR #710                     | Enable optional E2E & perf-stress jobs                |
 | [x]    | 002 | PR #710                     | Make flake-detector a required gate                   |
-| [ ]    | 003 | Issue #695                  | Kick-off Dependabot + weekly Trivy automation         |
+| [x]    | 003 | Issue #695                  | Kick-off Dependabot + weekly Trivy automation         |
 | [ ]    | 004 | Migrate_Slack_Adapter.md    | Migrate Slack adapter from ngrok to Cloudflare Tunnel |
 | [ ]    | 005 | Slack_Manifest_Update.md    | Update Slack manifest for Cloudflare Tunnel migration |
 

--- a/tasks/task-queue.md
+++ b/tasks/task-queue.md
@@ -1,10 +1,9 @@
-| Status | ID  | File                        | Description                                           |
-|--------|-----|-----------------------------|-------------------------------------------------------|
-| [x]    | 001 | PR #710                     | Enable optional E2E & perf-stress jobs                |
-| [x]    | 002 | PR #710                     | Make flake-detector a required gate                   |
-| [x]    | 003 | Issue #695                  | Kick-off Dependabot + weekly Trivy automation         |
-| [ ]    | 004 | Migrate_Slack_Adapter.md    | Migrate Slack adapter from ngrok to Cloudflare Tunnel |
-| [ ]    | 005 | Slack_Manifest_Update.md    | Update Slack manifest for Cloudflare Tunnel migration |
-
-
-<!-- nudge Wed Jun 18 17:47:14 WEST 2025 - mark task 001 complete -->
+| Status | ID  | File                       | Description                                               |
+|--------|-----|----------------------------|-----------------------------------------------------------|
+| [ ]    | 007 | task-ticker.yml            | Fix task-ticker trigger by removing branches-ignore: [main] |
+| [ ]    | 008 | architect_review.yml       | Deploy architect_review.yml auto-merge workflow to main   |
+| [x]    | 001 | PR #710                    | Enable optional E2E & perf-stress jobs                    |
+| [x]    | 002 | PR #710                    | Make flake-detector a required gate                       |
+| [x]    | 003 | Issue #695                 | Kick-off Dependabot + weekly Trivy automation             |
+| [ ]    | 004 | Migrate_Slack_Adapter.md   | Migrate Slack adapter from ngrok to Cloudflare Tunnel     |
+| [ ]    | 005 | Slack_Manifest_Update.md   | Update Slack manifest for Cloudflare Tunnel migration     |


### PR DESCRIPTION
Mark Task #003 as complete to trigger Engineer workflow.

This is a docs-only change that should get fast-pass treatment
with the new ci-summary workflow.

Expected: Engineer creates engineer-task-004 branch automatically.

🤖 Generated with [Claude Code](https://claude.ai/code)