### PR TITLE
Phase X: Local Runtime Enablement bullets

### DIFF
--- a/planning/architect-plan.md
+++ b/planning/architect-plan.md
@@ -45,3 +45,13 @@ Use [ ] for unchecked tasks and [x] for completed ones. -->
 | [ ]    | 038 | docs/automation_workflow.md         | Document PRD workflow                                                                           |
 | [ ]    | 039 | reviewer_middleware.md              | Implement reviewer middleware to enforce PRD-id & task-id in PR description                     |
 | [ ]    | 040 | kpi_monitor.yml                     | Add KPI monitor script to fail if Architect or Task-ticker success < 95%                       |
+
+
+#### Local Runtime Enablement
+- Scaffold services/memory (Qdrant + Postgres) in docker-compose
+- Add NATS message-bus service for agent events
+- Containerise architect, planner, engineer, reviewer agents with router.toml
+- Implement git->embedding ETL hook on post-commit
+- Port CI workflows to self-hosted runner service
+- Create router.toml mapping agents to local vs API LLM endpoints
+- Write plan-files-exist & task-count guards into local runner


### PR DESCRIPTION
## Summary
- Add Local Runtime Enablement section to architect-plan.md
- Seven atomic tasks to kick-off local, multi-agent runtime work
- Focus on containerization, message bus, and self-hosted CI

## Tasks Added
- Scaffold services/memory (Qdrant + Postgres) in docker-compose
- Add NATS message-bus service for agent events  
- Containerise architect, planner, engineer, reviewer agents with router.toml
- Implement git->embedding ETL hook on post-commit
- Port CI workflows to self-hosted runner service
- Create router.toml mapping agents to local vs API LLM endpoints
- Write plan-files-exist & task-count guards into local runner

🤖 Generated with [Claude Code](https://claude.ai/code)