### PR TITLE
Self-hosted runner scaffold

### DIFF
--- a/.github/workflows/local-ci-smoke.yml
+++ b/.github/workflows/local-ci-smoke.yml
@@ -1,0 +1,10 @@
+name: local-ci-smoke
+on:
+  pull_request:
+    branches: [main]
+    paths: ["docker-compose.yml"]
+jobs:
+  echo:
+    runs-on: self-hosted
+    steps:
+      - run: echo "🎉 Self-hosted runner responding!"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1504,3 +1504,20 @@ volumes:
     name: alfred-monitoring-dashboard-data
 networks:
   alfred-network:
+
+#######################################################################
+# Self-hosted GitHub Actions Runner
+#######################################################################
+services:
+  gh-runner:
+    image: my-gh-runner:latest   # build your custom runner image separately
+    environment:
+      GH_REPOSITORY: Digital-Native-Ventures/alfred-agent-platform-v2
+      GH_PAT: ${GH_PAT:?set in .env.runner}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - runner_data:/runner
+    restart: unless-stopped
+
+volumes:
+  runner_data:


### PR DESCRIPTION
## Summary
- Adds gh-runner service to docker-compose with Docker socket access
- Creates smoke-test workflow for self-hosted runner validation
- Includes environment configuration for GitHub repository connection

## Components Added
- **docker-compose.yml**: gh-runner service with volume mounts
- **.github/workflows/local-ci-smoke.yml**: Self-hosted runner smoke test

## Configuration
- Requires GH_PAT environment variable for authentication
- Maps Docker socket for containerized builds
- Persistent runner data volume
- Triggers on docker-compose.yml changes

## Setup Notes
- Build custom runner image: `my-gh-runner:latest`
- Set GH_PAT in .env.runner file
- Runner will automatically register with repository

🤖 Generated with [Claude Code](https://claude.ai/code)