### PR TITLE
Reviewer agent: ID enforcement

### DIFF
--- a/.github/workflows/reviewer-agent.yml
+++ b/.github/workflows/reviewer-agent.yml
@@ -1,0 +1,18 @@
+name: reviewer-agent
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+jobs:
+  reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Reviewer agent
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          pip install PyGithub
+          python -m reviewer.entrypoint

--- a/agents/reviewer/Dockerfile
+++ b/agents/reviewer/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY . .
-RUN pip install -r agents/$AGENT/requirements.txt || true
-ENTRYPOINT ["python","-m","$AGENT.entrypoint"]
+RUN pip install -r agents/reviewer/requirements.txt
+ENTRYPOINT ["python","-m","reviewer.entrypoint"]

--- a/agents/reviewer/requirements.txt
+++ b/agents/reviewer/requirements.txt
@@ -1,0 +1,1 @@
+PyGithub

--- a/agents/reviewer/reviewer/__init__.py
+++ b/agents/reviewer/reviewer/__init__.py
@@ -1,0 +1,1 @@
+# Reviewer agent package

--- a/agents/reviewer/reviewer/entrypoint.py
+++ b/agents/reviewer/reviewer/entrypoint.py
@@ -1,0 +1,32 @@
+import os, sys, re
+from github import Github
+
+RULES = {
+    "require_ids": {
+        "pattern": r"prd-id:.*\bPRD-[0-9]{4}-[0-9]+.*\btask-id:.*\b[0-9]+",
+        "message": "PR description must contain both `prd-id:` and `task-id:`."
+    }
+}
+
+def main():
+    pr_number = os.environ.get("PR_NUMBER")
+    repo_full = os.environ["GITHUB_REPOSITORY"]
+    token = os.environ["GITHUB_TOKEN"]
+    g = Github(token)
+    repo = g.get_repo(repo_full)
+    pr = repo.get_pull(int(pr_number))
+    body = pr.body or ""
+    errors = []
+    rule = RULES["require_ids"]
+    if not re.search(rule["pattern"], body, re.IGNORECASE | re.DOTALL):
+        errors.append(rule["message"])
+    if errors:
+        pr.create_issue_comment("\n".join(errors))
+        pr.create_review(body="Reviewer agent failed rules.", event="REQUEST_CHANGES")
+        sys.exit(1)
+    else:
+        pr.create_review(body="Reviewer agent passed all rules.", event="APPROVE")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/agents/reviewer/tests/test_rules.py
+++ b/agents/reviewer/tests/test_rules.py
@@ -1,0 +1,7 @@
+import re, reviewer.entrypoint as R
+def test_rule_regex():
+    ok = "Some text\nprd-id: PRD-2025-13\nsomething\n task-id: 041"
+    bad = "missing ids"
+    pat = R.RULES["require_ids"]["pattern"]
+    assert re.search(pat, ok, re.I|re.S)
+    assert not re.search(pat, bad, re.I|re.S)


### PR DESCRIPTION
Adds Reviewer agent container, rule-set, unit test and GitHub Action to enforce `prd-id` + `task-id` in every PR.

prd-id: PRD-2025-001
task-id: 039