### PR TITLE
Security: add gitleaks secret scanner

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,16 @@
+name: secret-scan
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: {fetch-depth: 0}
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          config-path: ".gitleaks.toml"
+          fail: true

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,6 @@
+[allowlist]
+description = "false positives & test keys"
+regexes = [
+  '''localhost[:/][0-9]{2,5}''',
+  '''dummy[_-]?secret''',
+]


### PR DESCRIPTION
Adds GitHub Actions workflow to block commits containing secrets or tokens.

prd-id: PRD-2025-001
task-id: 040