### PR TITLE
Prompt-cap utility (12k tokens)

### DIFF
--- a/.github/workflows/prompt-cap.yml
+++ b/.github/workflows/prompt-cap.yml
@@ -1,0 +1,15 @@
+name: prompt-cap
+on:
+  pull_request:
+    paths:
+      - "common/**"
+      - "agents/architect/**"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: {python-version: "3.12"}
+      - run: pip install pytest
+      - run: pytest tests/test_prompt_builder.py -q

--- a/agents/architect/architect/__init__.py
+++ b/agents/architect/architect/__init__.py
@@ -1,0 +1,1 @@
+# Architect agent package

--- a/agents/architect/architect/entrypoint.py
+++ b/agents/architect/architect/entrypoint.py
@@ -1,0 +1,16 @@
+from common.prompt_builder import build_prompt
+import sys
+
+def main():
+    """Architect agent entrypoint with prompt_builder integration."""
+    # Example usage
+    system_snippets = ["System context snippet 1", "System context snippet 2"]
+    user_query = "Generate a PRD for the new feature"
+    
+    prompt = build_prompt(system_snippets, user_query)
+    
+    print(f"Generated prompt with {len(prompt)} characters")
+    print("Prompt preview:", prompt[:200] + "..." if len(prompt) > 200 else prompt)
+
+if __name__ == "__main__":
+    main()

--- a/common/prompt_builder.py
+++ b/common/prompt_builder.py
@@ -1,0 +1,21 @@
+"""
+Build a prompt with hard 12k-token cap.
+Assumes tiktoken-like .encode() method; falls back to len(str)//4.
+"""
+
+MAX_TOKENS = 12_000
+CHUNK_LIMIT = 512   # each retrieved chunk max chars
+
+def _token_len(text, encoder=None):
+    if encoder:
+        return len(encoder.encode(text))
+    return int(len(text) / 4)  # heuristic
+
+def build_prompt(system_snippets, user_query, encoder=None):
+    """Assemble prompt: [system_snippets…, user query]. Each snippet cropped to CHUNK_LIMIT.
+    Ensures total tokens ≤ MAX_TOKENS by dropping oldest snippets last."""
+    sanitized = [s[:CHUNK_LIMIT] for s in system_snippets]
+    prompt_parts = sanitized + [user_query]
+    while _token_len("\n".join(prompt_parts), encoder) > MAX_TOKENS and len(prompt_parts) > 2:
+        prompt_parts.pop(0)  # drop oldest system snippet
+    return "\n".join(prompt_parts)

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,0 +1,9 @@
+from common.prompt_builder import build_prompt, _token_len, MAX_TOKENS
+def test_cap():
+    systems = ["sys "*3000]*5  # huge chunks
+    out = build_prompt(systems, "hello")
+    assert _token_len(out) <= MAX_TOKENS
+def test_order_preserved():
+    sys = ["A","B","C"]
+    prompt = build_prompt(sys, "Q")
+    assert prompt.splitlines()[0].startswith("B")  # 'A' dropped first


### PR DESCRIPTION
Adds common/prompt_builder.py, unit tests, CI workflow, and integrates into Architect entrypoint.

prd-id: PRD-2025-001
task-id: 041